### PR TITLE
Add null check on brush converter

### DIFF
--- a/GACore.Architecture/Properties/AssemblyInfo.cs
+++ b/GACore.Architecture/Properties/AssemblyInfo.cs
@@ -33,4 +33,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.6.1.0")]

--- a/GACore.Controls/Converters.cs
+++ b/GACore.Controls/Converters.cs
@@ -72,7 +72,8 @@ namespace GACore.Controls
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             IKingpinState kingpinState = value as IKingpinState;
-            return kingpinState.IsInFault();
+			if (kingpinState != null) return kingpinState.IsInFault();
+			else return true;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
@@ -83,9 +84,9 @@ namespace GACore.Controls
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            IKingpinState kingpinState = value as IKingpinState;
+			IKingpinState kingpinState = value as IKingpinState;
 			if (kingpinState != null) return kingpinState.IsVirtual ? Brushes.Cyan : Brushes.Black;
-			else return Brushes.DarkGray;
+			else return Brushes.Black;
 		}
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/GACore.Controls/Converters.cs
+++ b/GACore.Controls/Converters.cs
@@ -84,8 +84,9 @@ namespace GACore.Controls
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             IKingpinState kingpinState = value as IKingpinState;
-            return kingpinState.IsVirtual ? Brushes.Cyan : Brushes.Black;
-        }
+			if (kingpinState != null) return kingpinState.IsVirtual ? Brushes.Cyan : Brushes.Black;
+			else return Brushes.DarkGray;
+		}
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
             => throw new NotImplementedException("KingpinStateColorConverter ConvertBack()");

--- a/GACore.Controls/Properties/AssemblyInfo.cs
+++ b/GACore.Controls/Properties/AssemblyInfo.cs
@@ -48,4 +48,4 @@ using System.Windows;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.6.1.0")]

--- a/GACore.DemoApp/Properties/AssemblyInfo.cs
+++ b/GACore.DemoApp/Properties/AssemblyInfo.cs
@@ -48,4 +48,4 @@ using System.Windows;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.6.1.0")]

--- a/GACore.Test/Properties/AssemblyInfo.cs
+++ b/GACore.Test/Properties/AssemblyInfo.cs
@@ -32,4 +32,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.6.1.0")]

--- a/GACore/Properties/AssemblyInfo.cs
+++ b/GACore/Properties/AssemblyInfo.cs
@@ -32,4 +32,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.6.1.0")]


### PR DESCRIPTION
Increases protection on all affected converters - this has been tested to show that it fixes crash upon vehicle disconnect.